### PR TITLE
upstart: Add a setting example of 'logfile'

### DIFF
--- a/tools/ifcheckd.conf
+++ b/tools/ifcheckd.conf
@@ -15,6 +15,7 @@ env prog=ifcheckd
 # A setup of logging can be changed below.
 #env PCMK_logfacility=local1
 #env PCMK_logpriority=info
+#env PCMK_logfile=none
 
 script
 	exec $prog


### PR DESCRIPTION
If 'none' is not set to PCMK_logfile, a log will be outputted to /var/log/pacemaker.log by this change (https://github.com/ClusterLabs/pacemaker/commit/8410680fbd7d5d1fea8e411fdf32f9c3ebe889cb).
