### PR TITLE
Build: Stop using the deprecated form of AM_INIT_AUTOMAKE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,9 +2,9 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-#AC_INIT(FULL-PACKAGE-NAME, VERSION, BUG-REPORT-ADDRESS)
 AC_INIT(pm_extras, 2.0)
-AM_INIT_AUTOMAKE(pm_extras, 2.0)
+dnl Older distros may need: AM_INIT_AUTOMAKE($PACKAGE_NAME, $PACKAGE_VERSION)
+AM_INIT_AUTOMAKE
 AC_PROG_CC
 AC_PROG_LIBTOOL
 


### PR DESCRIPTION
This deters the following warning.

```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.0 (Maipo)

$ autoconf --version
autoconf (GNU Autoconf) 2.69

$ ./autogen.sh
configure.ac:7: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:7: http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
```
