### PR TITLE
Build: Stop using the $(shell pwd)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST              = HowToBuild_pm_extras.txt $(SPEC) tools
 $(TARFILE):
 	$(MAKE) dist
 
-RPM_ROOT		= $(shell pwd)
+RPM_ROOT		= $(CURDIR)
 RPMBUILDOPTS		= --define "_sourcedir $(RPM_ROOT)" \
 			  --define "_specdir $(RPM_ROOT)"
 


### PR DESCRIPTION
This deters the following warning.

```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.0 (Maipo)

$ autoconf --version
autoconf (GNU Autoconf) 2.69

$ ./autogen.sh
[snip]
Makefile.am:13: warning: shell pwd: non-POSIX variable name
Makefile.am:13: (probably a GNU make extension)
```
