### PR TITLE
Build: Delete the check of redundant mainloop.h and attrd.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -150,14 +150,6 @@ AC_CHECK_HEADER([corosync/cmap.h],
 	[],
 	[AC_MSG_ERROR("Not found corosync/cmap.h")]
 	)
-AC_CHECK_HEADER([crm/attrd.h],
-	[],
-	[AC_MSG_ERROR("Not found crm/attrd.h")]
-	)
-AC_CHECK_HEADER([crm/common/mainloop.h],
-	[],
-	[AC_MSG_ERROR("Not found crm/common/mainloop.h")]
-	)
 
 # RA
 AC_CHECK_HEADER([glue_config.h],


### PR DESCRIPTION
```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.0 (Maipo)

$ autoconf --version
autoconf (GNU Autoconf) 2.69

$ ./configure
[snip]
checking crm/common/mainloop.h usability... no
checking crm/common/mainloop.h presence... yes
configure: WARNING: crm/common/mainloop.h: present but cannot be compiled
configure: WARNING: crm/common/mainloop.h:     check for missing prerequisite headers?
configure: WARNING: crm/common/mainloop.h: see the Autoconf documentation
configure: WARNING: crm/common/mainloop.h:     section "Present But Cannot Be Compiled"
configure: WARNING: crm/common/mainloop.h: proceeding with the compiler's result
checking for crm/common/mainloop.h... no
configure: error: "Not found crm/common/mainloop.h"
$
$ cat config.log
[snip]
configure:12282: checking crm/common/mainloop.h usability
configure:12282: gcc -c -g -O2 -I/usr/include/heartbeat -I/usr/include/pacemaker -I/usr/include/corosync -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libxml2  -I/usr/include/heartbeat -I/usr/include/pacemaker -I/usr/include/corosync -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libxml2 conftest.c >&5
In file included from conftest.c:61:0:
/usr/include/pacemaker/crm/common/mainloop.h:51:1: error: unknown type name 'bool'
 bool mainloop_timer_running(mainloop_timer_t *t);
 ^
/usr/include/pacemaker/crm/common/mainloop.h:59:73: error: unknown type name 'bool'
 mainloop_timer_t *mainloop_timer_add(const char *name, guint period_ms, bool repeat, GSourceFunc cb, void *userdata);
                                                                         ^
configure:12282: $? = 1
configure: failed program was:
| /* confdefs.h */
[snip]
configure:12282: result: no
configure:12282: checking crm/common/mainloop.h presence
configure:12282: gcc -E  -I/usr/include/heartbeat -I/usr/include/pacemaker -I/usr/include/corosync -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/libxml2 conftest.c
configure:12282: $? = 0
configure:12282: result: yes
configure:12282: WARNING: crm/common/mainloop.h: present but cannot be compiled
configure:12282: WARNING: crm/common/mainloop.h:     check for missing prerequisite headers?
configure:12282: WARNING: crm/common/mainloop.h: see the Autoconf documentation
configure:12282: WARNING: crm/common/mainloop.h:     section "Present But Cannot Be Compiled"
configure:12282: WARNING: crm/common/mainloop.h: proceeding with the compiler's result
<font color="red">configure:12282: checking for crm/common/mainloop.h
configure:12282: result: no
configure:12286: error: "Not found crm/common/mainloop.h"</font>
[snip]
```

crm_config.h and crm/common/mainloop.h (& crm/attrd.h) are contained in pacemaker-libs-devel package.
Since crm_config.h is checked, the check of mainloop.h (& attrd.h) deletes. That is, it changes into the same check as [pm_diskd](https://github.com/linux-ha-japan/pm_diskd/blob/a46505b/configure.ac#L87).
