### PR TITLE
Changed so that /etc/sysconfig/pacemaker might be read for systemd. In o...

### DIFF
--- a/tools/ifcheckd.service
+++ b/tools/ifcheckd.service
@@ -10,6 +10,7 @@ PIDFile=/var/run/ifcheckd.pid
 ExecStart=/usr/sbin/ifcheckd
 Restart=always
 TimeoutStopSec=60min
+EnvironmentFile=-/etc/sysconfig/pacemaker
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
...rder to unify with a logging setup of pacemaker
